### PR TITLE
Add a separate display showing the time in Berlin TZ (fixes #17)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,8 +85,20 @@ fieldset button {
   font-size: 1.2em;
 }
 
+#countdown-time-container {
+  margin-top: 1.2em;
+  margin-bottom: 1.2em;
+}
+
 #countdown {
   font-size: 1.2em;
+  margin: 0em;
+}
+
+#countdown-berlin-tz {
+  font-size: 0.7em;
+  margin-top: 0.5em;
+  margin-bottom: 0em;
 }
 
 .helptext {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,10 @@
           data-content="COUNTDOWN_ERROR"
           class="hidden"
         ></p>
-        <p id="countdown"></p>
+        <div id="countdown-time-container">
+          <p id="countdown"></p>
+          <p id="countdown-berlin-tz"></p>
+        </div>
       </div>
       <div id="start-button-container" class="button-link hidden unhide-if-timeserver-ok">
         <a id="start-button" href="./form.html" data-content="START_REG" class="add-current-time-mock-if-set"></a>

--- a/js/countdown.js
+++ b/js/countdown.js
@@ -22,6 +22,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
 async function loadTime(config) {
   const countdown = document.getElementById("countdown");
+  const countdownBerlinTz = document.getElementById("countdown-berlin-tz")
   const longText = document.getElementById("countdown-text-long");
   const shortText = document.getElementById("countdown-text-short");
   const error = document.getElementById("countdown-error");
@@ -64,21 +65,27 @@ async function loadTime(config) {
       activateButton();
     } else {
       const useRelative = endTime - now < 3600000;
-
-      let timeString = new Date(time.targetTime).toLocaleDateString("en-GB", {
+      const targetTime = new Date(time.targetTime)
+      const timeFormat = {
         weekday: "long",
         year: "numeric",
         month: "long",
         day: "numeric",
         hour: "2-digit",
         minute: "2-digit"
-      });
+      }
+
+      let timeString = targetTime.toLocaleDateString("en-GB", timeFormat);
+      const berlinTimeString = targetTime.toLocaleDateString("en-GB", { ...timeFormat, timeZone: 'Europe/Berlin', timeZoneName: 'short' });
 
       if (useRelative) {
         timeString = formatRemaining(endTime - now);
+        countdownBerlinTz.classList.add("hidden");
         longText.classList.add("hidden");
         shortText.classList.remove("hidden");
       } else {
+        countdownBerlinTz.textContent = `(${berlinTimeString})`;
+        countdownBerlinTz.classList.remove("hidden");
         longText.classList.remove("hidden");
         shortText.classList.add("hidden");
       }


### PR DESCRIPTION
Fixes #17 

CET/CEST time is hidden when the counter goes in countdown mode. I used the Date formatting API and set it to `Europe/Berlin` so it should automatically adjust between CET & CEST.