### PR TITLE
Convert date checking to use Date objects

### DIFF
--- a/js/form.js
+++ b/js/form.js
@@ -290,7 +290,10 @@ function isValid(element, value) {
     case "phone":
       return isValidPhoneNumber(value)
     case "birthday":
-      return isValidBirthday(value)
+      const field = document.querySelector('[data-field="birthday"]');
+      const oldest = field.getAttribute("min");
+      const youngest = field.getAttribute("max");
+      return isValidBirthdayWithLimits(value, oldest, youngest)
     case "telegram":
       return isValidTelegram(value)
   }

--- a/js/validators.js
+++ b/js/validators.js
@@ -69,9 +69,17 @@ function isValidPhoneNumber(value) {
 }
 
 function isValidBirthday(value) {
-  const parsedDate = new Date(value)
+  // we first need to ensure the date value is in ISO date format yyyy-mm-dd (because the backend API expects that)
+  // note: if the user is on a modern browser, the date picker will ensure this, but there are oddball browsers that allow typing
+  if (/^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/.test(value)) {
+    // now ensure valid date and not in the future
+    const parsedDate = new Date(value)
+    return !isNaN(parsedDate.getDate()) && (parsedDate < Date.now())
+  }
+}
 
-  return !isNaN(parsedDate.getDate()) && (parsedDate < Date.now())
+function isValidBirthdayWithLimits(value, oldest, youngest) {
+  return isValidBirthday(value) && (value >= oldest) && (value <= youngest)
 }
 
 function isValidTelegram(value) {

--- a/js/validators.js
+++ b/js/validators.js
@@ -69,7 +69,9 @@ function isValidPhoneNumber(value) {
 }
 
 function isValidBirthday(value) {
-  return /^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/.test(value)
+  const parsedDate = new Date(value)
+
+  return !isNaN(parsedDate.getDate()) && (parsedDate < Date.now())
 }
 
 function isValidTelegram(value) {


### PR DESCRIPTION
Fixes #18 

Converts date validation to using native Date Javascript objects. This allows different date formats, (yyyy-mm-dd, mm/dd/yyyy, etc), and also ensures that the entered date occurs in the past.